### PR TITLE
Bugfix: remove cached instance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,38 +30,25 @@ const JSDOM_TEMPLATE = `
 `;
 
 const JSDOM_OPTIONS = { runScripts: 'dangerously', resources: 'usable' };
-const DOM = new JSDOM(JSDOM_TEMPLATE, JSDOM_OPTIONS);
 
-const cache = {};
+function getQuill() {
+  const DOM = new JSDOM(JSDOM_TEMPLATE, JSDOM_OPTIONS);
+  return new DOM.window.Quill('#editor');
+};
 
 exports.convertTextToDelta = (text) => {
-  if (!cache.quill) {
-    cache.quill = new DOM.window.Quill('#editor');
-  }
-
-  cache.quill.setText(text);
-
-  let delta = cache.quill.getContents();
-  return delta;
+  const quill = getQuill();
+  quill.setText(text);
+  return quill.getContents();
 };
 
 exports.convertHtmlToDelta = (html) => {
-  if (!cache.quill) {
-    cache.quill = new DOM.window.Quill('#editor');
-  }
-
-  let delta = cache.quill.clipboard.convert(html);
-
-  return delta;
+  const quill = getQuill();
+  return quill.clipboard.convert(html);
 };
 
 exports.convertDeltaToHtml = (delta) => {
-  if (!cache.quill) {
-    cache.quill = new DOM.window.Quill('#editor');
-  }
-
-  cache.quill.setContents(delta);
-
-  let html = cache.quill.root.innerHTML;
-  return html;
+  const quill = getQuill();
+  quill.setContents(delta);
+  return quill.root.innerHTML;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-quill-converter",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4593,9 +4593,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-quill-converter",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2893,9 +2893,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-quill-converter",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -574,9 +574,9 @@
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -588,9 +588,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
         }
       }
     },
@@ -2338,9 +2338,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
           "dev": true
         },
         "cssom": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-quill-converter",
-  "version": "0.3.3",
+  "name": "@drarok/node-quill-converter",
+  "version": "0.4.0",
   "description": "Convert HTML to Delta or Delta to HTML",
   "keywords": [
     "node",
@@ -9,14 +9,14 @@
     "convert",
     "html"
   ],
-  "homepage": "https://github.com/joelcolucci/node-quill-converter",
+  "homepage": "https://github.com/drarok/node-quill-converter",
   "bugs": {
-    "url": "https://github.com/joelcolucci/node-quill-converter/issues"
+    "url": "https://github.com/drarok/node-quill-converter/issues"
   },
   "main": "./lib/index.js",
   "author": "Joel Colucci",
   "license": "MIT",
-  "private": false,
+  "private": true,
   "scripts": {
     "test": "jest test"
   },
@@ -25,7 +25,6 @@
     "quill": "^1.3.6"
   },
   "devDependencies": {
-    "jest": "^25.1.0",
-    "leakage": "^0.5.0"
+    "jest": "^25.1.0"
   }
 }

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -1,11 +1,12 @@
-const { iterate } = require('leakage');
 const {
   convertTextToDelta,
   convertHtmlToDelta,
   convertDeltaToHtml } = require('../lib/index.js');
 
 
-describe('node-quill-converter', () => {
+xdescribe('node-quill-converter', () => {
+  const { iterate } = require('leakage');
+
   it('convertTextToDelta - does not leak', () => {
     iterate(() => {
       const text = 'hello, world';

--- a/test/node-quill-converter.test.js
+++ b/test/node-quill-converter.test.js
@@ -64,4 +64,20 @@ describe('node-quill-converter', () => {
 
     expect(htmlResult).toEqual(htmlExpected);
   });
+
+  it('GitHub Issue #22', () => {
+    const sampleData = [
+      `<pre>Hola</pre>`,
+      `<h3>Hello</h3>`,
+    ];
+
+    const test = () => {
+      sampleData.forEach((sample) => {
+        const delta = convertHtmlToDelta(sample);
+        convertDeltaToHtml(delta);
+      });
+    };
+
+    expect(test).not.toThrow();
+  });
 });


### PR DESCRIPTION
This fixes #22, at the cost of performance:

Before:
```
 FAIL  test/node-quill-converter.test.js
  node-quill-converter
    ✓ convertTextToDelta (77ms)
    ✓ convertHtmlToDelta (7ms)
    ✓ convertHtmlToDelta (3ms)
    ✓ GitHub Issue #2 (6ms)
```

After:
```
 PASS  test/node-quill-converter.test.js
  node-quill-converter
    ✓ convertTextToDelta (178ms)
    ✓ convertHtmlToDelta (108ms)
    ✓ convertHtmlToDelta (77ms)
    ✓ GitHub Issue #2 (76ms)
    ✓ GitHub Issue #22 (294ms)
```